### PR TITLE
Incluindo o RequiredHeaders

### DIFF
--- a/authenticate.go
+++ b/authenticate.go
@@ -142,7 +142,7 @@ func RequiredHeaders(headers ...string) gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		for _, c := range headers {
 			if content := ctx.GetHeader(c); content == "" {
-				ctx.AbortWithStatus(http.StatusBadRequest)
+				ctx.AbortWithStatus(http.StatusForbidden)
 				return
 			}
 		}

--- a/authenticate.go
+++ b/authenticate.go
@@ -136,3 +136,17 @@ func RequiredClaims(claims ...string) gin.HandlerFunc {
 		ctx.Next()
 	}
 }
+
+// RequiredHeaders ...
+func RequiredHeaders(headers ...string) gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		for _, c := range headers {
+			if content := ctx.GetHeader(c); content == "" {
+				ctx.AbortWithStatus(http.StatusBadRequest)
+				return
+			}
+		}
+
+		ctx.Next()
+	}
+}


### PR DESCRIPTION
Criado o método RequiredHeaders para validar os headers obrigatórios.

Exemplo : 
grok.RequiredHeaders("X-Current-Identity")