### PR TITLE
Cellphone generator

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -144,3 +144,22 @@ func MaskCellphone(value string) string {
 
 	return ddd + mask + rest
 }
+
+//GeneratorCellphone ...
+func GeneratorCellphone() string {
+	phoneString := ""
+	rand.Seed(time.Now().UTC().UnixNano())
+
+	dddArray := [3]int{ 11, 21, 51 }
+	ddd := dddArray[rand.Intn(2)]
+
+	phone := rand.Perm(8)
+
+	for _, c := range phone {
+		phoneString += strconv.Itoa(c)
+	}
+
+	phoneString = strconv.Itoa(ddd) + "9" + phoneString
+
+	return phoneString
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -54,3 +54,8 @@ func TestMaskCellphone(t *testing.T) {
 		assert.Equal(t, item.expected, result)
 	}
 }
+
+func TestGeneratorCellphone(t *testing.T) {
+	phone := grok.GeneratorCellphone()
+	assert.Equal(t, 11, len(phone))
+}


### PR DESCRIPTION
Gerador de número de celular.
Gera número de celular para os DDDs 11, 21 e 51.

**OBSERVAÇÃO : Cuidado ao utilizar, para não disparar SMS para eles. Podem ser números de telefone válidos de alguém.**